### PR TITLE
Create Apache variables for Debian 10

### DIFF
--- a/vars/Debian-10.yml
+++ b/vars/Debian-10.yml
@@ -1,0 +1,14 @@
+apache_conf_fragment_subdir: "conf-available"
+apache_conf_fragment_suffix: ".conf"
+apache_version: "2.4" 
+apache_pid_file: "/var/run/apache2$SUFFIX/apache2.pid"
+apache_packages:
+  - apache2
+  - libapache2-mod-rpaf
+
+apache_enabled_modules:
+  - mpm_prefork
+  - rewrite
+  - setenvif
+apache_disabled_modules:
+  - mpm_event


### PR DESCRIPTION
It is just a copy of the Debian 9 file since the package names have
stayed the same.