### PR TITLE
Update ports.conf and remove NameVirtualHost

### DIFF
--- a/templates/ports.conf.j2
+++ b/templates/ports.conf.j2
@@ -1,23 +1,15 @@
 # If you just change the port or add more ports here, you will likely also
 # have to change the VirtualHost statement in
-# /etc/apache2/sites-enabled/000-default
-# This is also true if you have upgraded from before 2.2.9-3 (i.e. from
-# Debian etch). See /usr/share/doc/apache2.2-common/NEWS.Debian.gz and
-# README.Debian.gz
+# /etc/apache2/sites-enabled/000-default.conf
 
-NameVirtualHost *:{{apache_port}}
 Listen {{apache_port}}
 
-<IfModule mod_ssl.c>
-    # If you add NameVirtualHost *:443 here, you will also have to change
-    # the VirtualHost statement in /etc/apache2/sites-available/default-ssl
-    # to <VirtualHost *:443>
-    # Server Name Indication for SSL named virtual hosts is currently not
-    # supported by MSIE on Windows XP.
-    Listen 443
-    NameVirtualhost *:443
+<IfModule ssl_module>
+	Listen 443
 </IfModule>
 
 <IfModule mod_gnutls.c>
-    Listen 443
+	Listen 443
 </IfModule>
+
+# vim: syntax=apache ts=4 sw=4 sts=4 sr noet


### PR DESCRIPTION
The NameVirtualHost directive is deprecated and has had no effect since
Apache 2.3.11 which predates Debian 8 (Jessie).  The new configuration
uses the Apache 2.4.38 (packaged in Debian 10) version of ports.conf as
a base but keeps the port number as a template.

This change removes the following note from the logs: "AH00548:
NameVirtualHost has no effect and will be removed in the next release
/etc/apache2/ports.conf:8"

More information:
https://httpd.apache.org/docs/2.4/mod/core.html#namevirtualhost
https://metadata.ftp-master.debian.org/changelogs//main/a/apache2/apache2_2.4.38-3+deb10u4_changelog

Another change brought by the newer ports.conf is that the first
IfModule directive now uses the module identifier instead of the module
file.  IfModule has supported module identifiers since Apache 2.1.

More information:
https://httpd.apache.org/docs/2.4/mod/core.html#ifmodule