### PR TITLE
Fix deprecated syntax for compability with newer Ansible versions

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,3 +1,3 @@
 # file: webserver/handlers/main.yml
 ---
-- include: apache.yml
+- import_tasks: apache.yml


### PR DESCRIPTION
Change deprecated include to import_tasks in main.yml of handlers. Works with both ansible-core 2.11.12 and 2.19.2.
